### PR TITLE
Use get() method instead of getheader for HTTPMessage instance. 

### DIFF
--- a/wialon/api.py
+++ b/wialon/api.py
@@ -138,7 +138,7 @@ class Wialon(object):
         except URLError as e:
             raise WialonError(0, unicode(e))
 
-        content_type = response.info().getheader('Content-Type')
+        content_type = response.info().get('Content-Type')
         result = response_content.decode('utf-8', errors='ignore')
         try:
             if content_type == 'application/json':


### PR DESCRIPTION
In Python 2, get() is a synonym for getheader(), which does not exist in Python 3.

Fix for #8 