### PR TITLE
Link for async lib in README.md not working

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,6 @@ Wialon
 
 `Wialon` is a Python wrapper for Remote Api. (Now with support for Python 3 since v1.0.2)
 
-For async implementation please check [o-murphy:py-aiowialon](https://github.com/o-murphy/py-aiowialon/)
-
 Installation
 ------------
     pip install python-wialon


### PR DESCRIPTION
Link to async lib (https://github.com/o-murphy/py-aiowialon/) is not available (404)
The user is also not available